### PR TITLE
Automatically append changelog to build comments.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/testfairy/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/testfairy/Messages.properties
@@ -1,0 +1,2 @@
+TestFairyNotifier.NoChanges=No changes.
+TestFairyNotifier.NewChanges=New changes:

--- a/src/main/resources/org/jenkinsci/plugins/testfairy/TestFairyNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testfairy/TestFairyNotifier/config.jelly
@@ -40,6 +40,10 @@
                 <f:textarea />
             </f:entry>
 
+            <f:entry title="Append Changelog to comment" field="appendChangelog">
+                <f:checkbox />
+            </f:entry>
+
             <f:section title="Video Settings">
                     <f:entry title="Video recording settings" field="video">
                         <f:select />


### PR DESCRIPTION
This allows testers to see what changes since
comment is always shown in email that send to them.
